### PR TITLE
Add SSL configuration options for Redis storage

### DIFF
--- a/debezium-bom/pom.xml
+++ b/debezium-bom/pom.xml
@@ -43,7 +43,7 @@
         <!-- Storages -->
 
         <!-- Redis -->
-        <version.jedis>4.1.1</version.jedis>
+        <version.jedis>6.0.0</version.jedis>
 
         <!-- S3 -->
         <version.s3>2.26.30</version.s3>

--- a/debezium-storage/debezium-storage-redis/src/main/java/io/debezium/storage/redis/RedisCommonConfig.java
+++ b/debezium-storage/debezium-storage-redis/src/main/java/io/debezium/storage/redis/RedisCommonConfig.java
@@ -44,6 +44,41 @@ public class RedisCommonConfig {
             .withDescription("Use SSL for Redis connection")
             .withDefault(DEFAULT_SSL_ENABLED);
 
+    private static final String DEFAULT_TRUSTSTORE_PATH = "";
+    private static final Field PROP_SSL_TRUSTSTORE_PATH = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "ssl.truststore.path")
+            .withDescription("Path to the truststore file")
+            .withDefault(DEFAULT_TRUSTSTORE_PATH);
+
+    private static final String DEFAULT_TRUSTSTORE_PASSWORD = "";
+    private static final Field PROP_SSL_TRUSTSTORE_PASSWORD = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "ssl.truststore.password")
+            .withDescription("Password for the truststore")
+            .withDefault(DEFAULT_TRUSTSTORE_PASSWORD);
+
+    private static final String DEFAULT_TRUSTSTORE_TYPE = "JKS";
+    private static final Field PROP_SSL_TRUSTSTORE_TYPE = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "ssl.truststore.type")
+            .withDescription("Type of the truststore (e.g., JKS, PKCS12)")
+            .withDefault(DEFAULT_TRUSTSTORE_TYPE);
+
+    private static final String DEFAULT_KEYSTORE_PATH = "";
+    private static final Field PROP_SSL_KEYSTORE_PATH = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "ssl.keystore.path")
+            .withDescription("Path to the keystore file")
+            .withDefault(DEFAULT_KEYSTORE_PATH);
+
+    private static final String DEFAULT_KEYSTORE_PASSWORD = "";
+    private static final Field PROP_SSL_KEYSTORE_PASSWORD = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "ssl.keystore.password")
+            .withDescription("Password for the keystore")
+            .withDefault(DEFAULT_KEYSTORE_PASSWORD);
+
+    private static final String DEFAULT_KEYSTORE_TYPE = "JKS";
+    private static final Field PROP_SSL_KEYSTORE_TYPE = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "ssl.keystore.type")
+            .withDescription("Type of the keystore (e.g., JKS, PKCS12)")
+            .withDefault(DEFAULT_KEYSTORE_TYPE);
+
+    private static final boolean DEFAULT_HOSTNAME_VERIFICATION = false;
+    private static final Field PROP_SSL_HOSTNAME_VERIFICATION_ENABLED = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "ssl.hostname.verification.enabled")
+            .withDescription("Enable hostname verification")
+            .withDefault(DEFAULT_HOSTNAME_VERIFICATION);
+
     private static final Integer DEFAULT_CONNECTION_TIMEOUT = 2000;
     private static final Field PROP_CONNECTION_TIMEOUT = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "connection.timeout.ms")
             .withDescription("Connection timeout (in ms)")
@@ -94,7 +129,15 @@ public class RedisCommonConfig {
     private int dbIndex;
     private String user;
     private String password;
+
     private boolean sslEnabled;
+    private String truststorePath;
+    private String truststorePassword;
+    private String truststoreType;
+    private String keystorePath;
+    private String keystorePassword;
+    private String keystoreType;
+    private boolean hostnameVerificationEnabled;
 
     private Integer initialRetryDelay;
     private Integer maxRetryDelay;
@@ -120,8 +163,15 @@ public class RedisCommonConfig {
     }
 
     protected List<Field> getAllConfigurationFields() {
-        return Collect.arrayListOf(PROP_ADDRESS, PROP_DB_INDEX, PROP_USER, PROP_PASSWORD, PROP_SSL_ENABLED, PROP_CONNECTION_TIMEOUT, PROP_SOCKET_TIMEOUT,
-                PROP_RETRY_INITIAL_DELAY, PROP_RETRY_MAX_DELAY, PROP_WAIT_ENABLED, PROP_WAIT_TIMEOUT, PROP_WAIT_RETRY_ENABLED, PROP_WAIT_RETRY_DELAY);
+        return Collect.arrayListOf(
+                PROP_ADDRESS, PROP_DB_INDEX, PROP_USER, PROP_PASSWORD,
+                PROP_SSL_ENABLED,
+                PROP_SSL_TRUSTSTORE_PATH, PROP_SSL_TRUSTSTORE_PASSWORD, PROP_SSL_TRUSTSTORE_TYPE,
+                PROP_SSL_KEYSTORE_PATH, PROP_SSL_KEYSTORE_PASSWORD, PROP_SSL_KEYSTORE_TYPE,
+                PROP_SSL_HOSTNAME_VERIFICATION_ENABLED,
+                PROP_CONNECTION_TIMEOUT, PROP_SOCKET_TIMEOUT,
+                PROP_RETRY_INITIAL_DELAY, PROP_RETRY_MAX_DELAY,
+                PROP_WAIT_ENABLED, PROP_WAIT_TIMEOUT, PROP_WAIT_RETRY_ENABLED, PROP_WAIT_RETRY_DELAY);
     }
 
     protected void init(Configuration config) {
@@ -129,7 +179,15 @@ public class RedisCommonConfig {
         dbIndex = config.getInteger(PROP_DB_INDEX);
         user = config.getString(PROP_USER);
         password = config.getString(PROP_PASSWORD);
+
         sslEnabled = config.getBoolean(PROP_SSL_ENABLED);
+        truststorePath = config.getString(PROP_SSL_TRUSTSTORE_PATH);
+        truststorePassword = config.getString(PROP_SSL_TRUSTSTORE_PASSWORD);
+        truststoreType = config.getString(PROP_SSL_TRUSTSTORE_TYPE);
+        keystorePath = config.getString(PROP_SSL_KEYSTORE_PATH);
+        keystorePassword = config.getString(PROP_SSL_KEYSTORE_PASSWORD);
+        keystoreType = config.getString(PROP_SSL_KEYSTORE_TYPE);
+        hostnameVerificationEnabled = config.getBoolean(PROP_SSL_HOSTNAME_VERIFICATION_ENABLED);
 
         initialRetryDelay = config.getInteger(PROP_RETRY_INITIAL_DELAY);
         maxRetryDelay = config.getInteger(PROP_RETRY_MAX_DELAY);
@@ -204,4 +262,31 @@ public class RedisCommonConfig {
         return waitRetryDelay;
     }
 
+    public String getTruststorePath() {
+        return truststorePath;
+    }
+
+    public String getTruststorePassword() {
+        return truststorePassword;
+    }
+
+    public String getTruststoreType() {
+        return truststoreType;
+    }
+
+    public String getKeystorePath() {
+        return keystorePath;
+    }
+
+    public String getKeystorePassword() {
+        return keystorePassword;
+    }
+
+    public String getKeystoreType() {
+        return keystoreType;
+    }
+
+    public boolean isHostnameVerificationEnabled() {
+        return hostnameVerificationEnabled;
+    }
 }

--- a/debezium-storage/debezium-storage-redis/src/main/java/io/debezium/storage/redis/history/RedisSchemaHistory.java
+++ b/debezium-storage/debezium-storage-redis/src/main/java/io/debezium/storage/redis/history/RedisSchemaHistory.java
@@ -55,8 +55,7 @@ public class RedisSchemaHistory extends AbstractSchemaHistory {
     private RedisSchemaHistoryConfig config;
 
     void connect() {
-        RedisConnection redisConnection = new RedisConnection(config.getAddress(), config.getDbIndex(), config.getUser(), config.getPassword(),
-                config.getConnectionTimeout(), config.getSocketTimeout(), config.isSslEnabled());
+        RedisConnection redisConnection = new RedisConnection(config);
         client = redisConnection.getRedisClient(RedisConnection.DEBEZIUM_SCHEMA_HISTORY, config.isWaitEnabled(), config.getWaitTimeout(),
                 config.isWaitRetryEnabled(), config.getWaitRetryDelay());
     }

--- a/debezium-storage/debezium-storage-redis/src/main/java/io/debezium/storage/redis/offset/RedisOffsetBackingStore.java
+++ b/debezium-storage/debezium-storage-redis/src/main/java/io/debezium/storage/redis/offset/RedisOffsetBackingStore.java
@@ -47,8 +47,7 @@ public class RedisOffsetBackingStore extends MemoryOffsetBackingStore {
 
     void connect() {
         closeClient();
-        RedisConnection redisConnection = new RedisConnection(config.getAddress(), config.getDbIndex(), config.getUser(), config.getPassword(),
-                config.getConnectionTimeout(), config.getSocketTimeout(), config.isSslEnabled());
+        RedisConnection redisConnection = new RedisConnection(config);
         client = redisConnection.getRedisClient(RedisConnection.DEBEZIUM_OFFSETS_CLIENT_NAME, config.isWaitEnabled(), config.getWaitTimeout(),
                 config.isWaitRetryEnabled(), config.getWaitRetryDelay());
     }


### PR DESCRIPTION
This change updates the Jedis client to version 6.0.0. and takes advantage of the newly introduced SSL options. 

The options are applied only if `redis.ssl.enabled` is true.

Configuration properties for each new SSL options:
`redis.ssl.truststore.path`: Specifies the path to the truststore file used for SSL.
`redis.ssl.truststore.password`: Specifies the password for the truststore file.
`redis.ssl.truststore.type`: Specifies the type of the truststore (e.g., JKS, PKCS12) (default: JKS).
`redis.ssl.keystore.path`: Specifies the path to the keystore file used for SSL.
`redis.ssl.keystore.password`: Specifies the password for the keystore file.
`redis.ssl.keystore.type`: Specifies the type of the keystore (e.g., JKS, PKCS12) (default: JKS).
`redis.ssl.hostname.verification.enabled`: Enables or disables hostname verification for SSL (default: false).